### PR TITLE
Make Quicklinks Open in New Tab

### DIFF
--- a/init/assets/scripts/semistatics.js
+++ b/init/assets/scripts/semistatics.js
@@ -42,6 +42,7 @@ function initQuicklinks() {
         const a = document.createElement("a");
         a.href = link.url;
         a.textContent = link.title;
+        a.target = "_blank";
 
         // Add to container.
         let order = [i, span, a];


### PR DESCRIPTION
This should be the last minor bugfix for `init()`.